### PR TITLE
Restore the ability to use brackets in prefix/suffix

### DIFF
--- a/qml/PrefixDialog.qml
+++ b/qml/PrefixDialog.qml
@@ -81,7 +81,7 @@ UM.Dialog
                 width: Math.floor(base.width * 0.8)
                 maximumLength: 255
                 validator: RegularExpressionValidator {
-                    regularExpression: /^[^\\\/\*\?\|\[\]\;\~\&\"]*$/
+                    regularExpression: /^[^\\\/\*\?\|\;\~\&\"]*$/
                 }
                 enabled: prefixJobNameCheckbox.checked
             }
@@ -98,7 +98,7 @@ UM.Dialog
                 width: Math.floor(base.width * 0.8)
                 maximumLength: 255
                 validator: RegularExpressionValidator {
-                    regularExpression: /^[^\\\/\*\?\|\[\]\;\~\&\"]*$/
+                    regularExpression: /^[^\\\/\*\?\|\;\~\&\"]*$/
                 }
                 enabled: prefixJobNameCheckbox.checked
             }

--- a/qml_qt5/PrefixDialog.qml
+++ b/qml_qt5/PrefixDialog.qml
@@ -82,7 +82,7 @@ UM.Dialog
                 width: Math.floor(base.width * 0.8)
                 maximumLength: 255
                 validator: RegExpValidator {
-                    regExp: /^[^\\\/\*\?\|\[\]\;\~\&\"]*$/
+                    regExp: /^[^\\\/\*\?\|\;\~\&\"]*$/
                 }
                 enabled: prefixJobNameCheckbox.checked
             }
@@ -99,7 +99,7 @@ UM.Dialog
                 width: Math.floor(base.width * 0.8)
                 maximumLength: 255
                 validator: RegExpValidator {
-                    regExp: /^[^\\\/\*\?\|\[\]\;\~\&\"]*$/
+                    regExp: /^[^\\\/\*\?\|\;\~\&\"]*$/
                 }
                 enabled: prefixJobNameCheckbox.checked
             }


### PR DESCRIPTION
There's no real reason that I can see to prevent the usage of brackets (`[]`) in file names. All OS's are totally fine with that, and my printers don't seem to have an issue with them either.
My tests show that removing this limitation doesn't hurt this plugin's functionality in any way.

Hope you consider accepting my PR :)