### PR TITLE
Feature/add material temperature and leading zero

### DIFF
--- a/PrintInformationPatches.py
+++ b/PrintInformationPatches.py
@@ -196,7 +196,7 @@ class PrintInformationPatches(QObject):
             "{printer_type}": self._abbreviate_name(self._global_stack.definition.getName()),
             "{printer_type_full}": self._global_stack.definition.getName(),
             "{layer_height}": self._abbreviate_number_leading_zero(self._global_stack.getProperty("layer_height", "value")),
-            "{machine_nozzle_size}": self._abbreviate_number(extruder_stack.getProperty("machine_nozzle_size", "value")),
+            "{machine_nozzle_size}": self._abbreviate_number_leading_zero(extruder_stack.getProperty("machine_nozzle_size", "value")),
             "{infill_sparse_density}": self._abbreviate_number(extruder_stack.getProperty("infill_sparse_density", "value")),
             "{speed_print}": self._abbreviate_number(extruder_stack.getProperty("speed_print", "value")),
             "{material_temperature}": self._abbreviate_number(int(float(extruder_stack.getProperty("material_print_temperature", "value")))),

--- a/PrintInformationPatches.py
+++ b/PrintInformationPatches.py
@@ -8,8 +8,12 @@ import os.path
 import unicodedata
 
 try:
+    from cura.ApplicationMetadata import CuraSDKVersion
+except ImportError: # Cura <= 3.6
+    CuraSDKVersion = "6.0.0"
+if CuraSDKVersion >= "8.0.0":
     from PyQt6.QtCore import Qt, QDate, QTime, QObject, pyqtProperty, pyqtSignal, pyqtSlot
-except ImportError:
+else:
     from PyQt5.QtCore import Qt, QDate, QTime, QObject, pyqtProperty, pyqtSignal, pyqtSlot
 
 from typing import Any, Optional, TYPE_CHECKING

--- a/PrintInformationPatches.py
+++ b/PrintInformationPatches.py
@@ -8,12 +8,8 @@ import os.path
 import unicodedata
 
 try:
-    from cura.ApplicationMetadata import CuraSDKVersion
-except ImportError: # Cura <= 3.6
-    CuraSDKVersion = "6.0.0"
-if CuraSDKVersion >= "8.0.0":
     from PyQt6.QtCore import Qt, QDate, QTime, QObject, pyqtProperty, pyqtSignal, pyqtSlot
-else:
+except ImportError:
     from PyQt5.QtCore import Qt, QDate, QTime, QObject, pyqtProperty, pyqtSignal, pyqtSlot
 
 from typing import Any, Optional, TYPE_CHECKING
@@ -195,10 +191,11 @@ class PrintInformationPatches(QObject):
             "{printer_name_full}": self._global_stack.getName(),
             "{printer_type}": self._abbreviate_name(self._global_stack.definition.getName()),
             "{printer_type_full}": self._global_stack.definition.getName(),
-            "{layer_height}": self._abbreviate_number(self._global_stack.getProperty("layer_height", "value")),
+            "{layer_height}": self._abbreviate_number_leading_zero(self._global_stack.getProperty("layer_height", "value")),
             "{machine_nozzle_size}": self._abbreviate_number(extruder_stack.getProperty("machine_nozzle_size", "value")),
             "{infill_sparse_density}": self._abbreviate_number(extruder_stack.getProperty("infill_sparse_density", "value")),
             "{speed_print}": self._abbreviate_number(extruder_stack.getProperty("speed_print", "value")),
+            "{material_temperature}": self._abbreviate_number(int(float(extruder_stack.getProperty("material_print_temperature", "value")))),
             "{material_flow}": self._abbreviate_number(extruder_stack.getProperty("material_flow", "value")),
             "{profile_name}": self._abbreviate_name(profile_name),
             "{profile_name_full}": profile_name,
@@ -237,6 +234,9 @@ class PrintInformationPatches(QObject):
 
     def _abbreviate_number(self, number: float) -> str:
         return str(number).replace(".", "")
+    
+    def _abbreviate_number_leading_zero(self, number: float) -> str:
+        return str(number)
 
     def _abbreviate_name(self, name: str) -> str:
         abbr_name = ""

--- a/qml/PrefixDialog.qml
+++ b/qml/PrefixDialog.qml
@@ -163,7 +163,7 @@ UM.Dialog
         TextEdit
         {
             text: "{printer_name}, {printer_name_full}, {printer_type}, {printer_type_full}, {layer_height}, {machine_nozzle_size}, {infill_sparse_density}, {speed_print}, {material_flow}, {profile_name}, {profile_name_full}, " +
-                  "{material_name}, {material_name_full}, {material_type}, {material_type_full}, {material_weight}, {print_time_hours}, {print_time_minutes}, {date_iso}, {date_year}, {date_month}, {date_day}, {time_iso}, {time_hour}, {time_minutes}"
+                  "{material_name}, {material_name_full}, {material_type}, {material_type_full}, {material_weight}, {print_time_hours}, {print_time_minutes}, {date_iso}, {date_year}, {date_month}, {date_day}, {material_temperature}, {time_iso}, {time_hour}, {time_minutes}"
             width: parent.width
             renderType: Text.NativeRendering
             readOnly: true

--- a/qml_qt5/PrefixDialog.qml
+++ b/qml_qt5/PrefixDialog.qml
@@ -164,7 +164,7 @@ UM.Dialog
         TextEdit
         {
             text: "{printer_name}, {printer_name_full}, {printer_type}, {printer_type_full}, {layer_height}, {machine_nozzle_size}, {infill_sparse_density}, {speed_print}, {material_flow}, {profile_name}, {profile_name_full}, " +
-                  "{material_name}, {material_name_full}, {material_type}, {material_type_full}, {material_weight}, {print_time_hours}, {print_time_minutes}, {date_iso}, {date_year}, {date_month}, {date_day}, {time_iso}, {time_hour}, {time_minutes}"
+                  "{material_name}, {material_name_full}, {material_type}, {material_type_full}, {material_weight}, {print_time_hours}, {print_time_minutes}, {date_iso}, {date_year}, {date_month}, {date_day}, {material_temperature}, {time_iso}, {time_hour}, {time_minutes}"
             width: parent.width
             renderType: Text.NativeRendering
             readOnly: true


### PR DESCRIPTION
Quick PR to allow you to have the material temperature added into a job name as well as a change that allows the layer_height to be `0.X` instead of `0X`

@fieldOfView 

for example:
{print_time_hours}h{print_time_minutes}m_{layer_height}mm_{material_temperature}C_{material_name_full}_{printer_name}
outputs
ModulR_Twin_Duct_6h12m_0.1mm_250C_Generic_ABS_CE3S1PRO.gcode
